### PR TITLE
Removing extra line

### DIFF
--- a/imageflow/views.py
+++ b/imageflow/views.py
@@ -336,7 +336,6 @@ def reduction(request, pk):
         'analysis': analysis.get_summary_obj(),
         'lightcurve': analysis.lightcurve,
         'image_filters': ImageFilter.objects.all(),
-
         'next_image': next_image,
     }
     if hasattr(analysis, 'reduction') and analysis.reduction:


### PR DESCRIPTION
The `template_args` dictionary contained an extra blank line which may severely impact the readability and flow of the code.
This change resolves that problem.